### PR TITLE
Fixed compiler warning in MicroViewSlider.

### DIFF
--- a/MicroView.cpp
+++ b/MicroView.cpp
@@ -1422,11 +1422,7 @@ size_t MicroView::write(uint8_t c) {
     Initialise the MicroViewSlider widget with style WIDGETSTYLE0 or WIDGETSTYLE1 or WIDGETSTYLE2 (like 0, but vertical) or WIDGETSTYLE3 (like 1, but vertical). If this list gets any longer, it might be better as a switch/case statement.
 */
 	MicroViewSlider::MicroViewSlider(uint8_t newx, uint8_t newy, int16_t min, int16_t max, uint8_t sty):MicroViewWidget(newx, newy, min, max) {
-		if (sty==WIDGETSTYLE0) {
-			style=0;
-			totalTicks=30;
-		}
-		else if (sty==WIDGETSTYLE1) {
+		if (sty==WIDGETSTYLE1) {
 			style=1;
 			totalTicks=60;
 		}
@@ -1438,7 +1434,7 @@ size_t MicroView::write(uint8_t c) {
 			style=3;
 			totalTicks=40;
 		}
-		else {		//unrecognized style, so use default
+		else {		// Use style 0 if specified or invalid
 			style=0;
 			totalTicks=30;
 		}
@@ -1458,16 +1454,14 @@ size_t MicroView::write(uint8_t c) {
 		offsetX=getX();
 		offsetY=getY();
 		
-		if(style==0)	
+		if (style==0)
 			majorLine=4;
-		else	if (style==1)	
+		else if (style==1)
 			majorLine=7;
-		else	if (style==2)
+		else if (style==2)
 			majorLine=3;
-		else if (style==3)
+		else
 			majorLine=5;
-
-
 
 //Horizontal styles, style 0 or 1
 


### PR DESCRIPTION
In drawFace, majorLine could be left uninitialised if style was invalid
(although this couldn't happen with the current code).
Also cleaned up the WIDGETSTYLE tests.
