### PR TITLE
Reverse direction of vertical sliders

### DIFF
--- a/MicroView.cpp
+++ b/MicroView.cpp
@@ -1541,12 +1541,13 @@ void MicroViewSlider::draw() {
 	offsetY=getY();
 
 	if (needFirstDraw) {
-		tickPosition= (((float)(prevValue-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 		if (style==0 || style==1){		//Horizontal
+			tickPosition= (((float)(prevValue-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineH(offsetX+tickPosition,offsetY, 3, WHITE, XOR);
 			uView.pixel(offsetX+1+tickPosition,offsetY+1, WHITE, XOR);
 		}
 		else {					//Vertical
+			tickPosition= (((float)(getMaxValue()-prevValue)/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineV(offsetX+7, offsetY+tickPosition, 3, WHITE, XOR);
 			uView.pixel(offsetX+6, offsetY+1+tickPosition, WHITE, XOR);
 		}
@@ -1556,23 +1557,25 @@ void MicroViewSlider::draw() {
 	}
 	else {
 		// Draw previous pointer in XOR mode to erase it
-		tickPosition= (((float)(prevValue-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 		if (style==0 || style==1){		//Horizontal
+			tickPosition= (((float)(prevValue-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineH(offsetX+tickPosition,offsetY, 3, WHITE, XOR);
 			uView.pixel(offsetX+1+tickPosition,offsetY+1, WHITE, XOR);
 		}
 		else {					//Vertical
+			tickPosition= (((float)(getMaxValue()-prevValue)/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineV(offsetX+7, offsetY+tickPosition, 3, WHITE, XOR);
 			uView.pixel(offsetX+6, offsetY+1+tickPosition, WHITE, XOR);
 		}
 
 		// Draw current pointer
-		tickPosition= (((float)(getValue()-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 		if (style==0 || style==1){		//Horizontal
+			tickPosition= (((float)(getValue()-getMinValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineH(offsetX+tickPosition,offsetY, 3, WHITE, XOR);
 			uView.pixel(offsetX+1+tickPosition,offsetY+1, WHITE, XOR);
 		}
 		else {					//Vertical
+			tickPosition= (((float)(getMaxValue()-getValue())/(float)(getMaxValue()-getMinValue()))*totalTicks);
 			uView.lineV(offsetX+7, offsetY+tickPosition, 3, WHITE, XOR);
 			uView.pixel(offsetX+6, offsetY+1+tickPosition, WHITE, XOR);
 		}


### PR DESCRIPTION
This new pull request replaces my previous two requests, which were difficult to merge due to changes on the main branch.

These changes will reverse the positioning of the pointer on vertical sliders. The lowest value will set the pointer to the bottom and the highest value will point to the top.

Also included are the changes to eliminate a compiler warning.
