### PR TITLE
Handle full signed 16 bit ranges for widgets.

### DIFF
--- a/MicroView.h
+++ b/MicroView.h
@@ -239,6 +239,7 @@ public:
 	void setMaxValue(int16_t max);
 	void setMinValue(int16_t max);
 	void setValue(int16_t val);
+	uint8_t getMaxValLen();
 	/** \brief Draw widget value overridden by child class. */
     virtual void draw(){};
     /** \brief Draw widget face overridden by child class. */
@@ -340,4 +341,8 @@ void MVSPIClass::detachInterrupt() {
 }
 
 extern MicroView uView;
+
+/** \brief Get the number of print characters for a 16 bit signed value. */
+uint8_t getInt16PrintLen(int16_t val);
+
 #endif


### PR DESCRIPTION
These changes allow the widgets to handle all minimum and maximum range values possible for the int16_t type that they accept (−32,768 to 32,767).

For cosmetic and space reasons, the position of the numeric value field is now adjusted based on the maximum characters that could be displayed for the current range, including a minus sign if necessary. For sliders, the leftmost position is as before but the position of the lowest digit will change based on the maximum field width. For gauges, the maximum field width is centred horizontally, at the same vertical position as before.

This means that for existing sketches, the position of a widget's numeric value may move compared to before these changes. Probably most noticeably, for multiple style 0 sliders with different range lengths, the values won't line up. This can be seen in the MicroViewSlider demo sketch.

Also, the MicroView's display isn't wide enough to handle a style 0 slider with 5 digit negative numbers. The lowest digit (at least) will wrap to the next line.

For a style 0 gauge with 5 digit negative numbers, the value will be slightly wider than the gauge circle. For a style 1 gauge, the value might not fit within the circle.

Apart from the differences noted above, the widgets work as before.
