### PR TITLE
Add uView.screenBuffer() for access to screen RAM.

### DIFF
--- a/MicroView.cpp
+++ b/MicroView.cpp
@@ -891,6 +891,14 @@ void MicroView::flipHorizontal(boolean flip) {
 	}
 }
 
+/** \brief Get pointer to screen buffer
+
+	Return a pointer to the start of the RAM screen buffer for direct access.
+*/
+uint8_t *MicroView::getScreenBuffer(void) {
+	return screenmemory;
+}
+
 /** \brief Parse command.
 
 	Command stored in serCmd array will be parsed to performed draw functions.
@@ -1325,14 +1333,6 @@ int MicroView::readSerial(void)
 	}
 	serInStr[i]='\0';
 	return i;
-}
-
-/** \brief Get pointer to screen buffer
-
-	Return a pointer to the start of the RAM screen buffer for direct access.
-*/
-uint8_t *MicroView::screenBuffer(void) {
-	return screenmemory;
 }
 
 // -------------------------------------------------------------------------------------

--- a/MicroView.h
+++ b/MicroView.h
@@ -192,7 +192,7 @@ public:
 	uint8_t getLCDHeight(void);
 	void setColor(uint8_t color);
 	void setDrawMode(uint8_t mode);
-	uint8_t *screenBuffer(void);
+	uint8_t *getScreenBuffer(void);
 
 	// Font functions
 	uint8_t getFontWidth(void);

--- a/keywords.txt
+++ b/keywords.txt
@@ -63,7 +63,7 @@ setValue	KEYWORD2
 draw	KEYWORD2
 reDraw	KEYWORD2
 drawFace	KEYWORD2
-screenBuffer	KEYWORD2
+getScreenBuffer	KEYWORD2
 checkComm	KEYWORD2
 
 #######################################


### PR DESCRIPTION
Returns a pointer to the start of the RAM screen buffer for direct write and read access.

Users can still mix all the regular display drawing and manipulation functions along side of using direct buffer access. For instance, you could use uView.clear(), uView.setCursor() and uView.print() to put some text somewhere on the screen. Then you could use direct screen buffer access to draw in other areas, before using uView.display() to show it all.
