### PR TITLE
Add keywords for existing functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,6 @@ MicroViewGauge	KEYWORD1
 #######################################
 
 begin	KEYWORD2
-invert	KEYWORD2
 clear	KEYWORD2
 invert	KEYWORD2
 contrast	KEYWORD2


### PR DESCRIPTION
Since the recently added MicroViewFlashingHeart example sketch uses them, I assume that the uView.setPageAddress(), uView.setColumnAddress(), and uView.data() functions are officially sanctioned for general use. These changes just add _setPageAddress_, _setColumnAddress_ and _data_ as keywords.

Also, the _getScreenBuffer_ keyword was moved to a more appropriate location in the file and a duplicate of the _invert_ keyword was removed .
