### PR TITLE
Replaced sprintf calls with dedicated code

### DIFF
--- a/MicroView.h
+++ b/MicroView.h
@@ -243,6 +243,7 @@ public:
 	void setMinValue(int16_t min);
 	void setMaxValue(int16_t max);
 	void setValue(int16_t val);
+	uint8_t getValLen();
 	uint8_t getMaxValLen();
 	/** \brief Draw widget value overridden by child class. */
     virtual void draw(){};
@@ -252,11 +253,14 @@ public:
 	void drawNumValue(int16_t value);
 	virtual ~MicroViewWidget(){};
 private:
+	void setMaxValLen();
 	uint8_t x;
 	uint8_t y;
 	int16_t maxValue;
 	int16_t minValue;
 	int16_t value;
+	uint8_t valLen;
+	uint8_t maxValLen;
 };
 
 class MicroViewSlider: public MicroViewWidget{

--- a/examples/MicroViewWidgetDemo/MicroViewWidgetDemo.ino
+++ b/examples/MicroViewWidgetDemo/MicroViewWidgetDemo.ino
@@ -208,7 +208,7 @@ void loop() {
 
   /*  ==================== Demo 13 ====================
       Gauge style 1, with no numeric value.
-      Value manually displayed beneath, as a letter.
+      Value manually displayed as a letter.
       Range 1 to 26 (A to Z).
       ================================================ */
   demoNumber(13);
@@ -246,15 +246,15 @@ void customSlider0(int16_t val) {
 
 // Update function for Demo 9
 void customSlider1(int16_t val) {
+  widget1->setValue(val);
   uint8_t offsetY = widget1->getY() - 10;
   uint8_t offsetX = widget1->getX() + 14;
   uView.setCursor(offsetX, offsetY);
   uView.print("      "); // erase the previous value in case it's longer
   // calculate the offset to centre the value
-  offsetX += ((widget1->getMaxValLen() - getInt16PrintLen(val)) * 3);
+  offsetX += ((widget1->getMaxValLen() - widget1->getValLen()) * 3);
   uView.setCursor(offsetX, offsetY);
   uView.print(val);
-  widget1->setValue(val);
 }
 
 // Update function for Demo 10
@@ -324,6 +324,7 @@ void spin(int16_t lowVal, int16_t highVal, int16_t stepSize,
           unsigned long stepDelay, void (*drawFunction)(int16_t val)) {
   drawFunction(lowVal);
   uView.display();
+  prevVal = lowVal;
   delay(1500);
 
   for (int16_t i = lowVal + stepSize; i <= highVal; i += stepSize) {

--- a/keywords.txt
+++ b/keywords.txt
@@ -63,6 +63,8 @@ getMaxValue	KEYWORD2
 setMaxValue	KEYWORD2
 setMinValue	KEYWORD2
 setValue	KEYWORD2
+getValLen	KEYWORD2
+getMaxValLen	KEYWORD2
 draw	KEYWORD2
 reDraw	KEYWORD2
 drawFace	KEYWORD2


### PR DESCRIPTION
Using **sprintf**, although convenient, generates a large amount of code. By replacing all **sprintf** calls with dedicated code, program size is reduced when widgets are used.

For example, for the following simple sketch the program size is reduced by 800 to 1000 or more bytes, depending on the version of the Arduino standard libraries used.

``` C++
#include <MicroView.h>

MicroViewWidget *widget;

void setup() {
  uView.begin();
  uView.clear(PAGE);
  widget = new MicroViewGauge(32, 24, 0, 100, WIDGETSTYLE1);
  widget->setValue(50);
  uView.display();
}

void loop() {
}
```

Additional changes included:
- Added a **getValLen** method for widgets, which returns the print length for the current value, similar to the existing **getMaxValLen**.
- The value for widgets is now initialised to the minimum value, instead of 0, because 0 could be outside the specified range.
- Added **getValLen** and **getMaxValLen** keywords.
- The **MicroViewWidgetDemo** example sketch was modified to use the new **getValLen** method, plus a few other small changes.
