### PR TITLE
Add optional second argument to widget setValue which can supress display buffer update 

### DIFF
--- a/MicroView.cpp
+++ b/MicroView.cpp
@@ -1441,19 +1441,29 @@ void MicroViewWidget::setMaxValue(int16_t max) {
 */
 uint8_t MicroViewWidget::getMaxValLen() { return maxValLen; }
 
-/** \brief Set current value.
+/** \brief Set current value and update widget.
 
-	The current value of the widget is set to the variable passed in.
+	The current value of the widget is set to the variable passed in and the widget is drawn with the new value.
 */
 void MicroViewWidget::setValue(int16_t val) {
+	setValue(val, true);
+}
+
+/** \brief Set current value with optional update.
+
+	The current value of the widget is set to the variable passed in. The widget is drawn with the new value if the doDraw argument is true.
+*/
+void MicroViewWidget::setValue(int16_t val, boolean doDraw) {
 	if ((val<=maxValue) && (val>=minValue)) {
 		value = val;
 		valLen = getInt16PrintLen(val);
-		this->draw();
+		if (doDraw) {
+			this->draw();
+		}
 	}
 }
 
-/** \brief Get the print length of the value
+/** \brief Get the print length of the value.
 
 	Return the number of characters that would be printed using uView.print(value) for the current value.
 */

--- a/MicroView.h
+++ b/MicroView.h
@@ -241,6 +241,7 @@ public:
 	void setMinValue(int16_t min);
 	void setMaxValue(int16_t max);
 	void setValue(int16_t val);
+	void setValue(int16_t val, boolean doDraw);
 	uint8_t getValLen();
 	uint8_t getMaxValLen();
 	/** \brief Draw widget value overridden by child class. */
@@ -273,7 +274,7 @@ public:
 private:
 	void drawPointer();
 	uint8_t style, totalTicks;
-	bool noValDraw;
+	boolean noValDraw;
 	int16_t prevValue;
 };
 
@@ -286,7 +287,7 @@ public:
 private:
 	void drawPointer();
 	uint8_t style, radius;
-	bool noValDraw;
+	boolean noValDraw;
 	int16_t prevValue;
 };
 


### PR DESCRIPTION
Overloaded the widget **setValue()** function to add a boolean argument **doDraw** which controls whether the display buffer is updated. This allows the value of a widget to be changed without modifying the contents of the display buffer.

Such a widget could be maintained "off screen". It could then be brought "on screen" by clearing the entire display, or at least the area where the widget resides, and then using the widget **reDraw()** function to display it. 

Also changed bool declarations to boolean, for consistency.